### PR TITLE
Update hardware_ps2_keyboard.asm

### DIFF
--- a/source/drivers/hardware_ps2_keyboard.asm
+++ b/source/drivers/hardware_ps2_keyboard.asm
@@ -20,6 +20,7 @@
 %define KEY_F4 0x3E
 
 %define KEY_A 0x1E
+%define KEY_B 0x1F
 
 key_code dd 0
 keyboard_shift dd 0


### PR DESCRIPTION
Doing this seems to fix the compilation error `error: symbol 'KEY_B' not defined`.
Although I don't know if the byte code is correct. You can correct it if you want.